### PR TITLE
Update dask-gateway

### DIFF
--- a/binder-gallery.yaml
+++ b/binder-gallery.yaml
@@ -4,6 +4,6 @@ description: >-
   Use Pangeo platform to efficiently analyze a stack of Landsat8 imagery on AWS
 gallery_repository: pangeo-gallery/pangeo-gallery
 binder_url: "https://aws-uswest2-binder.pangeo.io"
-binder_repo: pangeo-gallery/default-binder
-binder_ref: 2020.10.10
+binder_repo: pangeo-data/landsat-8-tutorial-gallery
+binder_ref: master
 binderbot_target_branch: binderbot-built

--- a/binder-gallery.yaml
+++ b/binder-gallery.yaml
@@ -4,6 +4,6 @@ description: >-
   Use Pangeo platform to efficiently analyze a stack of Landsat8 imagery on AWS
 gallery_repository: pangeo-gallery/pangeo-gallery
 binder_url: "https://aws-uswest2-binder.pangeo.io"
-binder_repo: pangeo-data/landsat-8-tutorial-gallery
-binder_ref: master
+binder_repo: pangeo-gallery/default-binder
+binder_ref: 2020.10.10
 binderbot_target_branch: binderbot-built

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,0 +1,1 @@
+FROM pangeo/pangeo-notebook:2020.07.26

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,2 +1,2 @@
 FROM pangeo/pangeo-notebook:2020.07.26
-RUN conda install -y -c conda-forge dask-gateway==0.8.0 && conda clean -afy
+RUN conda install -n notebook -y -c conda-forge dask-gateway==0.8.0 && conda clean -afy

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,1 +1,0 @@
-FROM pangeo/pangeo-notebook:2020.07.26

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,2 +1,2 @@
 FROM pangeo/pangeo-notebook:2020.07.26
-RUN conda install -n notebook -y -c conda-forge dask-gateway==0.8.0 && conda clean -afy
+RUN ${NB_PYTHON_PREFIX}/bin/pip install dask-gateway==0.8.0 --no-cache-dir

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,1 +1,2 @@
 FROM pangeo/pangeo-notebook:2020.07.26
+RUN conda install -y -c conda-forge dask-gateway==0.8.0 && conda clean -afy


### PR DESCRIPTION
The binder was recently updated to require Dask-Gateway>=0.8. This
updates the binder repo here to

1. Include a version with the required dask gateway.
2. Be checked by our automated tests, so that future deployments don't
   break the examples.

xref https://github.com/pangeo-gallery/pangeo-gallery/issues/30

Testing this out manually quick.